### PR TITLE
Introduce loop recur

### DIFF
--- a/text/_pages/00-intro-to-search.markdown
+++ b/text/_pages/00-intro-to-search.markdown
@@ -4,7 +4,19 @@ title:  "The basic ideas of search"
 categories: search
 ---
 
-# A simple example of search
+# {{ page.title }}
+
+## A simple example of search
+
+<!-- TOC depthFrom:1 depthTo:6 withLinks:1 updateOnSave:1 orderedList:0 -->
+
+- [{{ page.title }}](#-pagetitle-)
+	- [A simple example of search](#a-simple-example-of-search)
+	- [The size of search trees](#the-size-of-search-trees)
+	- [Repetition and search trees](#repetition-and-search-trees)
+	- [Next: Implementing these ideas in Clojure](#next-implementing-these-ideas-in-clojure)
+
+<!-- /TOC -->
 
 Let us first consider an _extremely_ (& deliberately) simple example. Imagine
 a little robot, Pat, on an integer grid at position (10, 10) who needs to get to
@@ -56,7 +68,7 @@ four options, one of which (`left`) leads to (9, 9); to keep the size of the
 diagram manageable we've omitted the other three states. From (9, 9) there are
 again four options, as illustrated in the figure.
 
-# The size of search trees
+## The size of search trees
 
 In theory Pat could find a path to (0, 0) by simply expanding this tree until
 they find the desired node. Even in this very simple example, however, this
@@ -79,7 +91,7 @@ of go [are much larger still](https://senseis.xmp.net/?NumberOfPossibleGoGames):
 
 Yikes!
 
-# Repetition and search trees
+## Repetition and search trees
 
 The search tree above also illustrates an annoying property of most search
 trees: there is often repetition, and frequently lots of it. In our diagram
@@ -100,7 +112,7 @@ want to further explore that state. If we later find a "cheaper" way to reach
 that state, then our interest in it might increase and we might
 want to (re)explore the paths from that state.
 
-# Next: Implementing these ideas in Clojure
+## Next: Implementing these ideas in Clojure
 
 In [the next installment]({% link _pages/01-simple-states-in-clojure.markdown %}) we'll
 look at how to represent and manipulate these

--- a/text/_pages/01-simple-states-in-clojure.markdown
+++ b/text/_pages/01-simple-states-in-clojure.markdown
@@ -4,6 +4,17 @@ title:  "Implementing simple states in Clojure"
 categories: search clojure
 ---
 
+# {{ page.title }}
+
+<!-- TOC depthFrom:1 depthTo:6 withLinks:1 updateOnSave:1 orderedList:0 -->
+
+- [{{ page.title }}](#-pagetitle-)
+	- [Representing states](#representing-states)
+	- [Generating "child" states](#generating-child-states)
+	- [Next: Breadth-first and depth-first search](#next-breadth-first-and-depth-first-search)
+
+<!-- /TOC -->
+
 In [the previous installment]({% link _pages/00-intro-to-search.markdown %}) we
 looked at a (very) simple example of search. In this installment we'll look
 at how to implement that in Clojure, and some of the most important (if

--- a/text/_pages/02-simple-search-algorithms.markdown
+++ b/text/_pages/02-simple-search-algorithms.markdown
@@ -6,6 +6,16 @@ categories: search clojure
 
 # {{ page.title }}
 
+<!-- TOC depthFrom:1 depthTo:6 withLinks:1 updateOnSave:1 orderedList:0 -->
+
+- [{{ page.title }}](#-pagetitle-)
+	- [A general approach to search](#a-general-approach-to-search)
+	- [Depth-first search](#depth-first-search)
+	- [Breadth-first search](#breadth-first-search)
+	- [Actually implementing search](#actually-implementing-search)
+
+<!-- /TOC -->
+
 In [the previous installment]({% link _pages/01-simple-states-in-clojure.markdown %}) we
 looked at how we might represent (very) simple kinds of search states
 in Clojure. In this installment we'll look

--- a/text/_pages/03-clean-up-search-implementation.markdown
+++ b/text/_pages/03-clean-up-search-implementation.markdown
@@ -6,6 +6,20 @@ categories: search clojure
 
 # {{ page.title }}
 
+<!-- TOC depthFrom:1 depthTo:6 withLinks:1 updateOnSave:1 orderedList:0 -->
+
+- [{{ page.title }}](#-pagetitle-)
+	- [Avoiding duplicate exploration](#avoiding-duplicate-exploration)
+	- [So many arguments!](#so-many-arguments)
+		- [Encapsulating problems](#encapsulating-problems)
+		- [Encapsulating search algorithms](#encapsulating-search-algorithms)
+	- [The new version of `search`](#the-new-version-of-search)
+	- [Yay – it works!](#yay-it-works)
+	- [loop-recur to further reduce arguments](#loop-recur-to-further-reduce-arguments)
+	- [Next: Heuristic search](#next-heuristic-search)
+
+<!-- /TOC -->
+
 In [the previous installment]({% link _pages/02-simple-search-algorithms.markdown %}) we
 developed an working initial implementation of our simple search algorithms in
 Clojure. Our code can be tidied up in several ways, and the logic of the search


### PR DESCRIPTION
This adds a section where we show how we can rewrite our `search` function using `loop`-`recur`. This improves efficiency (although perhaps slightly), avoids stack overflows for long searches, and avoids passing around `search-algorithm` and `problem` over and over in our recursions.

It also adds tables-of-contents to all the existing pages.

This closes #4.